### PR TITLE
initialize repo as an npm project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "dam",
+  "version": "0.0.1",
+  "description": "Digital asset management project",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ylijokic/DAM.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/ylijokic/DAM/issues"
+  },
+  "homepage": "https://github.com/ylijokic/DAM#readme"
+}


### PR DESCRIPTION
For help with reviewing a PR look at this link: https://help.github.com/en/articles/reviewing-proposed-changes-in-a-pull-request
And feel free to try things out like leaving comments on lines of code or comments on the PR itself, even if you're only making them to test things out.

This PR closes issue #3 

This PR adds a `package.json` file to keep track of our npm modules that are needed for our project. Also adds some meta information like the name of our project, license, authors, etc.

If you don't know about npm, this is a good "getting started" link: https://nodesource.com/blog/an-absolute-beginners-guide-to-using-npm/

Just for an FYI, there is an alternative to `npm` called `Yarn`. It's developed by Facebook and has it's own advantages, but `npm` is kind of the "default" for a Node project like ours. We might switch to it in the future, but I think it'll be easier starting with npm.